### PR TITLE
feat(project): include bindable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import {Config} from 'aurelia-view-manager';
+import {Config}    from 'aurelia-view-manager';
+import {getLogger} from 'aurelia-logging';
 
 export function configure(aurelia) {
   aurelia.plugin('aurelia-form');
@@ -9,3 +10,9 @@ export function configure(aurelia) {
 
   aurelia.globalResources('./filter');
 }
+
+const logger = getLogger('aurelia-filter');
+
+export {
+  logger
+};


### PR DESCRIPTION
- when defined it uses these paths to allow filtering on

- when both exclude and include columns is defined, a warning is shown and the
  exclude paths are ignored.