### PR TITLE
fix(project): make sure criteria matches the selected enum value

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -89,11 +89,11 @@ export class Filter extends CriteriaBuilder {
           data = Object.assign(this.buildFieldData(block[field]), {field: field});
           if (!this.filters[i]) {
             // create a new block
-            return this.create(undefined, data);
+            return this.create(undefined, data, true);
           }
 
           // Add AND condition to the current block
-          this.create(i, data);
+          this.create(i, data, true);
         });
       });
 
@@ -105,11 +105,11 @@ export class Filter extends CriteriaBuilder {
 
       if (i === 0) {
         // create the first block
-        return this.create(undefined, data);
+        return this.create(undefined, data, true);
       }
 
       // Add AND condition to the first block
-      this.create(0, data);
+      this.create(0, data, true);
     });
   }
 
@@ -136,7 +136,7 @@ export class Filter extends CriteriaBuilder {
     return {operator: key, value: field[key]};
   }
 
-  create(blockIndex, data) {
+  create(blockIndex, data, skipOnChange) {
     // prevent adding a non-existing field to the filter (leads to selecting the wrong field in the dropdown)
     if (data && data.field) {
       let options = this.fieldElement.options.map(option => option.value);
@@ -153,6 +153,14 @@ export class Filter extends CriteriaBuilder {
     valueElement.type = this.fieldTypes[fieldName] || 'string';
 
     if (valueElement.type === 'select') {
+      if (!skipOnChange) {
+        data = {
+          field   : fieldName,
+          value   : this.fieldEnumerations[fieldName][0],
+          operator: this.operatorElement.options[0].value
+        };
+      }
+
       valueElement.options = this.fieldEnumerations[fieldName];
     }
 
@@ -165,11 +173,20 @@ export class Filter extends CriteriaBuilder {
 
     // create filter
     if (typeof blockIndex !== 'undefined') {
-      return this.filters[blockIndex].push(filter);
+      this.filters[blockIndex].push(filter);
+      if (!skipOnChange && valueElement.type === 'select') {
+        this.onChange(blockIndex, this.filters[blockIndex].length -1, true);
+      }
+
+      return;
     }
 
     // create block
     this.filters.push([filter]);
+
+    if (!skipOnChange && valueElement.type === 'select') {
+      this.onChange(this.filters.length -1, 0, true);
+    }
   }
 
   destroy(blockIndex, index) {


### PR DESCRIPTION
fix(project): make sure criteria matches the selected enum value

BREAKING CHANGE: An optional boolean parameter has been added to the
“create” method. This parameter should be set to “true” if you want to
update the criteria object as soon as the new filter block has been
created with a “select” type.